### PR TITLE
hpc_emerg: use sigaltstack to handle bad %rsp value

### DIFF
--- a/main.c
+++ b/main.c
@@ -5,8 +5,16 @@
 
 void func_b(void)
 {
-	for (size_t i = 0; i < 100; i++)
-		BUG_ON(1);
+	__asm__ volatile(
+		"xorq\t%%rsp, %%rsp\n\t"
+		"addq\t$100, %%rsp\n\t"
+		"movq\t(%%rsp), %%rax\n\t"
+		:
+		:
+		: "memory"
+	);
+	// for (size_t i = 0; i < 100; i++)
+	// 	BUG_ON(1);
 }
 
 


### PR DESCRIPTION
Aleksey Covacevice wrote:
> I hope you're aware that introspection through signal handlers is not
> reliable. Eg.: if your stack is corrupted somehow, there's little
> chance you can do anything else (since you can't even safely allocate
> local storage).

Use sigaltstack() to guarantee some stack space even in stack corruption
scenarios.

Suggested-by: Aleksey Covacevice
Link: https://t.me/assemblybr/37701
Signed-off-by: Ammar Faizi <ammarfaizi2@gnuweeb.org>

```
The following changes since commit 19dfae6b163efb93c039e706c543db49aa6d47da:

  README.md: add maintainer (2021-08-15 17:49:07 +0700)

are available in the Git repository at:

  https://github.com/ammarfaizi2/hpc_emerg dev_ammarfaizi2

for you to fetch changes up to 8e5629ffd1dd36d716da9ec24cda2955c43a1865:

  hpc_emerg: use sigaltstack to handle bad %rsp value (2021-08-16 16:38:52 +0700)

----------------------------------------------------------------
Ammar Faizi (1):
      hpc_emerg: use sigaltstack to handle bad %rsp value

 main.c                     | 12 ++++++++++--
 src/emerg/arch/x64/emerg.c | 21 +++++++++++++++++----
 2 files changed, 27 insertions(+), 6 deletions(-)
```